### PR TITLE
ssh增加证书认证功能

### DIFF
--- a/cachecloud-open-common/src/main/java/com/sohu/cache/util/ConstUtils.java
+++ b/cachecloud-open-common/src/main/java/com/sohu/cache/util/ConstUtils.java
@@ -1,5 +1,6 @@
 package com.sohu.cache.util;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -95,6 +96,9 @@ public class ConstUtils {
 
     public static String DEFAULT_PASSWORD = "cachecloud";
     public static String PASSWORD = DEFAULT_PASSWORD;
+
+    public static String SSH_PRIVATE_KEY_FILE_PATH = null;
+    public static File SSH_PRIVATE_KEY = null;
 
     public static int DEFAULT_SSH_PORT_DEFAULT = 22;
     public static int SSH_PORT_DEFAULT = DEFAULT_SSH_PORT_DEFAULT;

--- a/cachecloud-open-web/src/main/java/com/sohu/cache/machine/PortGenerator.java
+++ b/cachecloud-open-web/src/main/java/com/sohu/cache/machine/PortGenerator.java
@@ -75,7 +75,7 @@ public class PortGenerator {
     public static String getMaxPortStrOld(String ip, int sshPort) throws SSHException {
         String redisPidCmd = "ps -ef | grep redis | grep -v 'grep' |  awk -F '*:' '{print $2}' " +
                 " | awk -F ' ' '{print $1}' | sort -r | head -1";
-        return SSHUtil.execute(ip, sshPort, ConstUtils.USERNAME, ConstUtils.PASSWORD, redisPidCmd);
+        return SSHUtil.execute(ip, sshPort, redisPidCmd);
     }
     
     /**
@@ -87,7 +87,7 @@ public class PortGenerator {
      */
      public static String getMaxPortStr(String ip, int sshPort) throws SSHException {
         String redisPidCmd = "ps -ef | grep redis | grep -v 'grep'";
-        String redisProcessStr = SSHUtil.execute(ip, sshPort, ConstUtils.USERNAME, ConstUtils.PASSWORD, redisPidCmd);
+        String redisProcessStr = SSHUtil.execute(ip, sshPort, redisPidCmd);
         if (StringUtils.isBlank(redisProcessStr)) {
             return EmptyObjectConstant.EMPTY_STRING;
         }

--- a/cachecloud-open-web/src/main/java/com/sohu/cache/machine/impl/MachineCenterImpl.java
+++ b/cachecloud-open-web/src/main/java/com/sohu/cache/machine/impl/MachineCenterImpl.java
@@ -167,7 +167,7 @@ public class MachineCenterImpl implements MachineCenter {
         MachineStats machineStats = null;
         try {
             int sshPort = SSHUtil.getSshPort(ip);
-            machineStats = SSHUtil.getMachineInfo(ip, sshPort, ConstUtils.USERNAME, ConstUtils.PASSWORD);
+            machineStats = SSHUtil.getMachineInfo(ip, sshPort);
             machineStats.setHostId(hostId);
             if (machineStats != null) {
                 infoMap.put(MachineConstant.Ip.getValue(), machineStats.getIp());

--- a/cachecloud-open-web/src/main/java/com/sohu/cache/ssh/SSHTemplate.java
+++ b/cachecloud-open-web/src/main/java/com/sohu/cache/ssh/SSHTemplate.java
@@ -1,9 +1,6 @@
 package com.sohu.cache.ssh;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -72,10 +69,19 @@ public class SSHTemplate {
         conn.connect(null, CONNCET_TIMEOUT, CONNCET_TIMEOUT);
 		String username = ConstUtils.USERNAME,
 				password = ConstUtils.PASSWORD;
-        boolean isAuthenticated = conn.authenticateWithPassword(username, password);
-        if (isAuthenticated == false) {
-            throw new Exception("SSH authentication failed with [ userName: " + 
-            		username + ", password: " + password + "]");
+		File privateKey = ConstUtils.SSH_PRIVATE_KEY;
+        boolean isAuthenticated = false;
+		String errMesg = null;
+		if (null != privateKey) {
+			isAuthenticated = conn.authenticateWithPublicKey(username, privateKey, password);
+			errMesg = "privateKeyPath: " + privateKey.getAbsolutePath();
+		} else {
+			isAuthenticated = conn.authenticateWithPassword(username, password);
+			errMesg = "password: " + password;
+		}
+        if (!isAuthenticated) {
+            throw new Exception("SSH authentication failed with [ userName: " +
+					username + ", " + errMesg + "]");
         }
         return conn;
     }

--- a/cachecloud-open-web/src/main/java/com/sohu/cache/ssh/SSHTemplate.java
+++ b/cachecloud-open-web/src/main/java/com/sohu/cache/ssh/SSHTemplate.java
@@ -36,26 +36,22 @@ public class SSHTemplate {
 	private static ThreadPoolExecutor taskPool = new ThreadPoolExecutor(
 			200, 200, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(1000), 
 			new ThreadFactoryBuilder().setNameFormat("SSH-%d").setDaemon(true).build());
-	
+
 	public Result execute(String ip, SSHCallback callback) throws SSHException{
-		return execute(ip,ConstUtils.DEFAULT_SSH_PORT_DEFAULT, ConstUtils.USERNAME, 
-				ConstUtils.PASSWORD, callback);
+		return execute(ip, ConstUtils.SSH_PORT_DEFAULT, callback);
 	}
-	
+
 	/**
 	 * 通过回调执行命令
 	 * @param ip
 	 * @param port
-	 * @param username
-	 * @param password
 	 * @param callback 可以使用Session执行多个命令
 	 * @throws SSHException 
 	 */
-    public Result execute(String ip, int port, String username, String password, 
-    		SSHCallback callback) throws SSHException{
+    public Result execute(String ip, int port, SSHCallback callback) throws SSHException{
         Connection conn = null;
         try {
-            conn = getConnection(ip, port, username, password);
+            conn = getConnection(ip, port);
             return callback.call(new SSHSession(conn, ip+":"+port));
         } catch (Exception e) {
             throw new SSHException("SSH err: " + e.getMessage(), e);
@@ -65,18 +61,17 @@ public class SSHTemplate {
     }
     
     /**
-     * 获取连接并校验
+     * 获取连接并校验, 使用默认的用户名、密码
      * @param ip
      * @param port
-     * @param username
-     * @param password
      * @return Connection
      * @throws Exception
      */
-    private Connection getConnection(String ip, int port, 
-    		String username, String password) throws Exception {
+    private Connection getConnection(String ip, int port) throws Exception {
     	Connection conn = new Connection(ip, port);
         conn.connect(null, CONNCET_TIMEOUT, CONNCET_TIMEOUT);
+		String username = ConstUtils.USERNAME,
+				password = ConstUtils.PASSWORD;
         boolean isAuthenticated = conn.authenticateWithPassword(username, password);
         if (isAuthenticated == false) {
             throw new Exception("SSH authentication failed with [ userName: " + 

--- a/cachecloud-open-web/src/main/java/com/sohu/cache/ssh/SSHUtil.java
+++ b/cachecloud-open-web/src/main/java/com/sohu/cache/ssh/SSHUtil.java
@@ -80,7 +80,7 @@ public class SSHUtil {
         final MachineStats systemPerformanceEntity =  new MachineStats();
         systemPerformanceEntity.setIp(ip);
         
-        sshTemplate.execute(ip, port, userName, password, new SSHCallback() {
+        sshTemplate.execute(ip, port, new SSHCallback() {
 			public Result call(SSHSession session) {
 				//解析top命令
 				session.executeCommand(COMMAND_TOP, new DefaultLineProcessor() {
@@ -196,7 +196,7 @@ public class SSHUtil {
         }
         port = IntegerUtil.defaultIfSmallerThan0(port, ConstUtils.SSH_PORT_DEFAULT);
         
-        Result rst = sshTemplate.execute(ip, port, username, password, new SSHCallback() {
+        Result rst = sshTemplate.execute(ip, port, new SSHCallback() {
 			public Result call(SSHSession session) {
 				return session.executeCommand(command);
 			}
@@ -219,7 +219,7 @@ public class SSHUtil {
      */
     private static boolean scpFileToRemote(String ip, int port, String username,
     		String password, final String localPath, final String remoteDir) throws SSHException{
-    	Result rst = sshTemplate.execute(ip, port, username, password, new SSHCallback() {
+        Result rst = sshTemplate.execute(ip, port, new SSHCallback() {
 			public Result call(SSHSession session) {
 				return session.scpToDir(localPath, remoteDir, "0644");
 			}

--- a/cachecloud-open-web/src/main/java/com/sohu/cache/ssh/SSHUtil.java
+++ b/cachecloud-open-web/src/main/java/com/sohu/cache/ssh/SSHUtil.java
@@ -47,6 +47,17 @@ public class SSHUtil {
     private final static SSHTemplate sshTemplate = new SSHTemplate();
 
     /**
+     * 重载，使用默认用户名和密码
+     * @param ip
+     * @param port
+     * @return
+     * @throws SSHException
+     */
+    public static MachineStats getMachineInfo(String ip, int port) throws SSHException {
+        return getMachineInfo(ip, port, ConstUtils.USERNAME, ConstUtils.PASSWORD);
+    }
+
+    /**
      * Get HostPerformanceEntity[cpuUsage, memUsage, load] by ssh.<br>
      * 方法返回前已经释放了所有资源，调用方不需要关心
      *
@@ -56,7 +67,7 @@ public class SSHUtil {
      * @throws Exception
      * @since 1.0.0
      */
-    public static MachineStats getMachineInfo(String ip, int port, String userName, 
+    private static MachineStats getMachineInfo(String ip, int port, String userName,
     		String password) throws SSHException {
         if (StringUtil.isBlank(ip)) {
             try {
@@ -177,7 +188,7 @@ public class SSHUtil {
      * @param password 密码
      * @param command  要执行的命令
      */
-    public static String execute(String ip, int port, String username, String password, 
+    private static String execute(String ip, int port, String username, String password,
     		final String command) throws SSHException {
 
         if (StringUtil.isBlank(command)) {
@@ -206,7 +217,7 @@ public class SSHUtil {
      * @return
      * @throws SSHException
      */
-    public static boolean scpFileToRemote(String ip, int port, String username, 
+    private static boolean scpFileToRemote(String ip, int port, String username,
     		String password, final String localPath, final String remoteDir) throws SSHException{
     	Result rst = sshTemplate.execute(ip, port, username, password, new SSHCallback() {
 			public Result call(SSHSession session) {
@@ -247,6 +258,18 @@ public class SSHUtil {
     public static String execute(String ip, String cmd) throws SSHException {
         int sshPort = SSHUtil.getSshPort(ip);
         return execute(ip, sshPort, ConstUtils.USERNAME, ConstUtils.PASSWORD, cmd);
+    }
+
+    /**
+     * 重载，使用默认用户名和密码
+     * @param ip
+     * @param port
+     * @param cmd
+     * @return
+     * @throws SSHException
+     */
+    public static String execute(String ip, int port, String cmd) throws SSHException {
+        return execute(ip, port, ConstUtils.USERNAME, ConstUtils.PASSWORD, cmd);
     }
 
     /**

--- a/cachecloud-open-web/src/main/java/com/sohu/cache/web/service/impl/ConfigServiceImpl.java
+++ b/cachecloud-open-web/src/main/java/com/sohu/cache/web/service/impl/ConfigServiceImpl.java
@@ -1,5 +1,6 @@
 package com.sohu.cache.web.service.impl;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -72,7 +73,25 @@ public class ConfigServiceImpl implements ConfigService {
                 ConstUtils.DEFAULT_PASSWORD);
         logger.info("{}: {}", "ConstUtils.PASSWORD", ConstUtils.PASSWORD);
 
-        
+        ConstUtils.SSH_PRIVATE_KEY_FILE_PATH = MapUtils.getString(configMap, "cachecloud.machine.ssh.privatekey.path", null);
+        logger.info("{}: {}", "ConstUtils.SSH_PRIVATE_KEY_FILE_PATH", ConstUtils.SSH_PRIVATE_KEY_FILE_PATH);
+
+        // check the validation of key file path
+        if (null != ConstUtils.SSH_PRIVATE_KEY_FILE_PATH && !ConstUtils.SSH_PRIVATE_KEY_FILE_PATH.trim().isEmpty()) {
+            File keyFile = new File(ConstUtils.SSH_PRIVATE_KEY_FILE_PATH);
+            if (keyFile.exists()) {
+                if (keyFile.isFile()) {
+                    ConstUtils.SSH_PRIVATE_KEY = keyFile;
+                    logger.info("Load SSH key file: {}, use key file to authorize instead of password",
+                            ConstUtils.SSH_PRIVATE_KEY_FILE_PATH);
+                } else {
+                    logger.error("SSH key file: {} exist, but not file", ConstUtils.SSH_PRIVATE_KEY_FILE_PATH);
+                }
+            } else {
+                logger.error("SSH key file: {} not exist", ConstUtils.SSH_PRIVATE_KEY_FILE_PATH);
+            }
+        }
+
         ConstUtils.SSH_PORT_DEFAULT = Integer.parseInt(MapUtils.getString(configMap, "cachecloud.machine.ssh.port",
                 String.valueOf(ConstUtils.DEFAULT_SSH_PORT_DEFAULT)));
         logger.info("{}: {}", "ConstUtils.SSH_PORT_DEFAULT", ConstUtils.SSH_PORT_DEFAULT);

--- a/cachecloud-open-web/src/test/java/com/sohu/test/util/SSHUtilTest.java
+++ b/cachecloud-open-web/src/test/java/com/sohu/test/util/SSHUtilTest.java
@@ -1,5 +1,6 @@
 package com.sohu.test.util;
 
+import com.sohu.cache.util.ConstUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -24,7 +25,9 @@ public class SSHUtilTest extends Assert{
         int port = 22;
         String userName = "cachecloud-open";
         String password = "cachecloud-open";
-        MachineStats machineStats = SSHUtil.getMachineInfo(ip, port, userName, password);
+        ConstUtils.USERNAME = userName;
+        ConstUtils.PASSWORD = password;
+        MachineStats machineStats = SSHUtil.getMachineInfo(ip, port);
         logger.info("ip {} machineStats: {}", machineStats);
     }
     

--- a/script/cachecloud.sql
+++ b/script/cachecloud.sql
@@ -851,7 +851,8 @@ CREATE TABLE `system_config` (
 --
 
 insert into system_config(config_key,config_value,info,status,order_id) values('cachecloud.machine.ssh.name','cachecloud','机器ssh用户名',1,1);
-insert into system_config(config_key,config_value,info,status,order_id) values('cachecloud.machine.ssh.password','cachecloud','机器ssh密码',1,2);
+insert into system_config(config_key,config_value,info,status,order_id) values('cachecloud.machine.ssh.password','cachecloud','机器ssh密码或私钥密码',1,2);
+insert into system_config(config_key,config_value,info,status,order_id) values('cachecloud.machine.ssh.privatekey.path','','机器ssh私钥路径',1,2);
 insert into system_config(config_key,config_value,info,status,order_id) values('cachecloud.machine.ssh.port','22','机器ssh端口',1,3);
 insert into system_config(config_key,config_value,info,status,order_id) values('cachecloud.admin.user.name','admin','cachecloud-admin用户名',1,4);
 insert into system_config(config_key,config_value,info,status,order_id) values('cachecloud.admin.user.password','admin','cachelcoud-admin密码',1,5);


### PR DESCRIPTION
1. 将对`ConstUtils.USERNAME`、`ConstUtils.PASSWORD`的访问都收拢到`SSHTemplate.getConnection`这个方法中
2. 在system_config表中增加一项：
`insert into system_config(config_key,config_value,info,status,order_id) values('cachecloud.machine.ssh.privatekey.path','','机器ssh私钥路径',1,2);`
来支持 私钥路径 的设置
3. 增加`ConstUtils.SSH_PRIVATE_KEY_FILE_PATH`、`ConstUtils.SSH_PRIVATE_KEY`来支持在`SSHTemplate.getConnection`使用私钥进行鉴权
4. 当`ConstUtils.SSH_PRIVATE_KEY`不为空时，使用私钥进行鉴权，鉴权时passphase使用`ConstUtils.PASSWORD`；否则，使用用户名密码鉴权