### PR TITLE
修复ssh模板中写死了22端口，这里改成SSH_PORT_DEFAULT这个变量可以通过管理后台,系统配置去修改机器ssh端口

### DIFF
--- a/cachecloud-open-web/src/main/java/com/sohu/cache/ssh/SSHTemplate.java
+++ b/cachecloud-open-web/src/main/java/com/sohu/cache/ssh/SSHTemplate.java
@@ -40,7 +40,7 @@ public class SSHTemplate {
 			new ThreadFactoryBuilder().setNameFormat("SSH-%d").setDaemon(true).build());
 	
 	public Result execute(String ip, SSHCallback callback) throws SSHException{
-		return execute(ip,ConstUtils.DEFAULT_SSH_PORT_DEFAULT, ConstUtils.USERNAME, 
+		return execute(ip,ConstUtils.SSH_PORT_DEFAULT, ConstUtils.USERNAME,
 				ConstUtils.PASSWORD, callback);
 	}
 	


### PR DESCRIPTION
修复ssh模板中写死了22端口，这里改成SSH_PORT_DEFAULT这个变量可以通过管理后台,系统配置去修改机器ssh端口。ConstUtils.DEFAULT_SSH_PORT_DEFAULT = 22