### PR TITLE
兼容redis-4.0.12中，cluster nodes 命令中端口后面会有@符号

### DIFF
--- a/cachecloud-open-client/cachecloud-jedis/src/main/java/redis/clients/util/ClusterNodeInformationParser.java
+++ b/cachecloud-open-client/cachecloud-jedis/src/main/java/redis/clients/util/ClusterNodeInformationParser.java
@@ -34,6 +34,11 @@ public class ClusterNodeInformationParser {
   public HostAndPort getHostAndPortFromNodeLine(String[] nodeInfoPartArray, HostAndPort current) {
     String stringHostAndPort = nodeInfoPartArray[HOST_AND_PORT_INDEX];
 
+    int index = stringHostAndPort.indexOf("@");
+    if (index != -1 ){
+        stringHostAndPort = stringHostAndPort.substring(0, index);
+    }
+
     String[] arrayHostAndPort = stringHostAndPort.split(":");
     return new HostAndPort(arrayHostAndPort[0].isEmpty() ? current.getHost() : arrayHostAndPort[0],
         arrayHostAndPort[1].isEmpty() ? current.getPort() : Integer.valueOf(arrayHostAndPort[1]));


### PR DESCRIPTION
redis 4.0.12版本中 cluster nodes命令结果如下。在端口后面会多一个@符号，
10.1.21.159:6389> cluster nodes
e759e0104fc4976e6c14c595f849b8941bee834c 10.1.21.164:6394@16394 master - 0 1556092972452 0 connected 5462-10923
052f956f2e605afb8f68ade62b97fdc6f5315a8c 10.1.21.164:6393@16393 master - 0 1556092972000 6 connected 0-5461
927fabf4b56eb833ea85c5a70ca67960b30fddba 10.1.21.171:6384@16384 slave a1cd8349183aa30dfd078d3fb719848dc7a5a5cd 0 1556092974456 7 connected
9352f8f18e9a6e4db4a1e73d5332842b256f7e1b 10.1.21.171:6383@16383 slave e759e0104fc4976e6c14c595f849b8941bee834c 0 1556092973453 4 connected
4290b10ac70f9a50ad2362a6ab62604a631baa76 10.1.21.159:6389@16389 myself,slave 052f956f2e605afb8f68ade62b97fdc6f5315a8c 0 1556092974000 1 connected
a1cd8349183aa30dfd078d3fb719848dc7a5a5cd 10.1.21.159:6390@16390 master - 0 1556092973000 7 connected 10924-16383