### PR TITLE
修复script中chown命令参数错误bug

### DIFF
--- a/redis-ecs/script/cachecloud-init.sh
+++ b/redis-ecs/script/cachecloud-init.sh
@@ -50,12 +50,12 @@ checkExist() {
       echo -e "\033[41;36m delete existed user: $1. \033[0m"
       userdel -r "$1"
       createUser "$1" "$2"
-      init "$1" "$2"
+      init "$1"
       return 0
     fi
   else
     createUser "$1" "$2"
-    init "$1" "$2"
+    init "$1"
   fi
   return 0
 }
@@ -87,11 +87,11 @@ init() {
   mkdir -p /data/redis
 
   # change owner
-  chown -R $1:$2 /opt/cachecloud
-  chown -R $1:$2 /tmp/cachecloud
-  chown -R $1:$2 /home/$1
+  chown -R $1:$1 /opt/cachecloud
+  chown -R $1:$1 /tmp/cachecloud
+  chown -R $1:$1 /home/$1
   chown -R $1 /var/run
-  chown -R $1:$2 /data/redis
+  chown -R $1:$1 /data/redis
   echo -e "\033[41;36m OK: init done. \033[0m"
 }
 
@@ -135,7 +135,11 @@ installRedis() {
 
     if [[ $? == 0 ]]; then
       echo -e "\033[41;36m OK: ${redisTarGz} is installed, exit. \033[0m"
-      chown -R $1:$2 ${redisDir}
+      chown -R $1:
+      
+      
+      
+      ${redisDir}
       if [[ ${redisVersion} == "redis-5.0.9" ]]; then
         export PATH=$PATH:${redisDir}/src
         echo $PATH


### PR DESCRIPTION
脚本默认创建的用户名、分组、密码都是一样的没有问题。
但当使用不一样的密码执行脚本的时候，chown命令中的分组参数应该传入用户名而不是密码。