### PR TITLE
fix(sec): upgrade org.quartz-scheduler:quartz to 2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <spring.cloud.version>Hoxton.SR4</spring.cloud.version>
         <logback.version>1.2.11</logback.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <quartz.version>2.2.1</quartz.version>
+        <quartz.version>2.3.2</quartz.version>
         <mysql.java.version>8.0.29</mysql.java.version>
         <druid-version>1.1.3</druid-version>
         <mybatis-spring-boot.version>1.3.1</mybatis-spring-boot.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.quartz-scheduler:quartz 2.2.1
- [CVE-2019-13990](https://www.oscs1024.com/hd/CVE-2019-13990)


### What did I do？
Upgrade org.quartz-scheduler:quartz from 2.2.1 to 2.3.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS