### PR TITLE
在部署 Redis Cluster 时，支持手动指定集群拓扑

### DIFF
--- a/cachecloud-web/src/main/java/com/sohu/cache/task/TaskService.java
+++ b/cachecloud-web/src/main/java/com/sohu/cache/task/TaskService.java
@@ -289,7 +289,7 @@ public interface TaskService {
      * @param parentTaskId           父任务id
      * @return
      */
-    long addRedisClusterAppTask(long appId, long appAuditId, int maxMemory, List<String> redisServerMachineList,
+    long addRedisClusterAppTask(long appId, long appAuditId, int maxMemory, List<String> appDeployInfoList, List<String> redisServerMachineList,
                                 int masterPerMachine, String dbVersion,String moduleinfos, long parentTaskId);
 
     /**

--- a/cachecloud-web/src/main/java/com/sohu/cache/task/constant/TaskConstants.java
+++ b/cachecloud-web/src/main/java/com/sohu/cache/task/constant/TaskConstants.java
@@ -592,7 +592,7 @@ public class TaskConstants {
     /**
      * 最大内存限制(MB)
      */
-    public final static int MAX_MEMORY_LIMIT = 1024 * 20;
+    public final static int MAX_MEMORY_LIMIT = 1024 * 10;
 
     /**
      * 一次分配每个机器最大rediserver实例数

--- a/cachecloud-web/src/main/java/com/sohu/cache/task/constant/TaskConstants.java
+++ b/cachecloud-web/src/main/java/com/sohu/cache/task/constant/TaskConstants.java
@@ -109,6 +109,7 @@ public class TaskConstants {
     /**
      * twemproxy
      */
+    public final static String APP_DEPLOY_INFO_LIST_KEY = "appDeployInfoList";
     public final static String REDIS_SERVER_MACHINE_LIST_KEY = "redisServerMachineList";
     public final static String REDIS_SENTINEL_MACHINE_LIST_KEY = "redisSentinelMachineList";
     public final static String NUT_CRACKER_MACHINE_LIST_KEY = "nutCrackerMachineList";
@@ -591,7 +592,7 @@ public class TaskConstants {
     /**
      * 最大内存限制(MB)
      */
-    public final static int MAX_MEMORY_LIMIT = 1024 * 10;
+    public final static int MAX_MEMORY_LIMIT = 1024 * 20;
 
     /**
      * 一次分配每个机器最大rediserver实例数

--- a/cachecloud-web/src/main/java/com/sohu/cache/task/impl/TaskServiceImpl.java
+++ b/cachecloud-web/src/main/java/com/sohu/cache/task/impl/TaskServiceImpl.java
@@ -522,11 +522,12 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
-    public long addRedisClusterAppTask(long appId, long appAuditId, int maxMemory, List<String> redisServerMachineList, int masterPerMachine, String dbVersion,String moduleinfos, long parentTaskId) {
+    public long addRedisClusterAppTask(long appId, long appAuditId, int maxMemory, List<String> appDeployInfoList, List<String> redisServerMachineList, int masterPerMachine, String dbVersion,String moduleinfos, long parentTaskId) {
         Map<String, Object> paramMap = new HashMap<String, Object>();
         paramMap.put(TaskConstants.APPID_KEY, appId);
         paramMap.put(TaskConstants.AUDIT_ID_KEY, appAuditId);
         paramMap.put(TaskConstants.REDIS_SERVER_MAX_MEMORY_KEY, maxMemory);
+        paramMap.put(TaskConstants.APP_DEPLOY_INFO_LIST_KEY,appDeployInfoList);
         paramMap.put(TaskConstants.REDIS_SERVER_MACHINE_LIST_KEY, redisServerMachineList);
         paramMap.put(TaskConstants.MASTER_PER_MACHINE_KEY, masterPerMachine);
         paramMap.put(TaskConstants.VERSION_KEY, dbVersion.replaceAll(RedisConstUtils.REDIS_VERSION_PREFIX,""));

--- a/cachecloud-web/src/main/java/com/sohu/cache/task/tasks/RedisClusterAppDeployTask.java
+++ b/cachecloud-web/src/main/java/com/sohu/cache/task/tasks/RedisClusterAppDeployTask.java
@@ -50,6 +50,13 @@ public class RedisClusterAppDeployTask extends BaseTask {
      */
     private long auditId;
 
+
+    /**
+     * redis server部署实例列表
+     */
+    private List<String> appDeployInfoList;
+
+
     /**
      * redis server机器列表
      */
@@ -153,6 +160,14 @@ public class RedisClusterAppDeployTask extends BaseTask {
             return TaskFlowStatusEnum.ABORT;
         }
 
+       //appDeployInfo
+        String appDeployInfoStr = MapUtils.getString(paramMap, TaskConstants.APP_DEPLOY_INFO_LIST_KEY);
+        appDeployInfoList = JSONArray.parseArray(appDeployInfoStr, String.class);
+        if (CollectionUtils.isEmpty(appDeployInfoList)) {
+            logger.error(marker, "task {} appDeployInfoList is empty", taskId);
+            return TaskFlowStatusEnum.ABORT;
+        }
+
         //redis server machine
         String redisServerMachineStr = MapUtils.getString(paramMap, TaskConstants.REDIS_SERVER_MACHINE_LIST_KEY);
         redisServerMachineList = JSONArray.parseArray(redisServerMachineStr, String.class);
@@ -241,7 +256,7 @@ public class RedisClusterAppDeployTask extends BaseTask {
      */
     public TaskFlowStatusEnum generateInstanceNodes() {
 
-        redisServerNodes = instancePortService.generateRedisServerNodeList(appId, redisServerMachineList, masterPerMachine, maxMemory);
+        redisServerNodes = instancePortService.generateRedisServerNodeList(appId, appDeployInfoList,  masterPerMachine, maxMemory);
         if (CollectionUtils.isEmpty(redisServerNodes)) {
             logger.warn(marker, "redisServerNodes is empty, appId is {}, redisServerMachineList is {}, masterPerMachine is {}, maxMemory is {}",
                     appId, redisServerMachineList, masterPerMachine, maxMemory);

--- a/cachecloud-web/src/main/java/com/sohu/cache/web/controller/AppManageController.java
+++ b/cachecloud-web/src/main/java/com/sohu/cache/web/controller/AppManageController.java
@@ -512,6 +512,7 @@ public class AppManageController extends BaseController {
                                            int sentinelNum,
                                            int pikaNum,
                                            int twemproxyNum,
+                                           String appDeployInfo,
                                            String redisMachines,
                                            String sentinelMachines,
                                            String twemproxyMachines,
@@ -634,6 +635,7 @@ public class AppManageController extends BaseController {
                                            int sentinelNum,
                                            int pikaNum,
                                            int twemproxyNum,
+                                           String appDeployInfo,
                                            String redisMachines,
                                            String sentinelMachines,
                                            String twemproxyMachines,
@@ -646,12 +648,14 @@ public class AppManageController extends BaseController {
         AppUser appUser = getUserInfo(request);
         logger.warn("user {} appid:{} ,appAuditId:{}, importantLevel:{} ,isSetPasswd:{},versionId:{},customPassword:{}", appUser.getName(), appid, appAuditId, importantLevel, isSetPasswd, versionId, customPassword);
         logger.info("type:{} ,maxMemory:{} MB ", type, maxMemory);
+        logger.info("appDeployInfo :{} ", appDeployInfo);
         logger.info("redisMachines:{} ,num:{} ", redisMachines, redisNum);
         logger.info("sentinelMachines:{} ,num:{} ", sentinelMachines, sentinelNum);
         logger.info("twemproxyMachines:{} ,num:{} ", twemproxyMachines, twemproxyNum);
         logger.info("pikaMachines:{} ,num:{} ", pikaMachines, pikaNum);
         logger.info("moduleinfos:{} ", moduleinfos);
         try {
+            List<String> appDeployInfolist = Arrays.asList(appDeployInfo.split("\n"));
             List<String> redisMachinelist = Arrays.asList(redisMachines.split(";"));
             List<String> sentinelMachinelist = Arrays.asList(sentinelMachines.split(";"));
             List<String> twemproxyMachinelist = Arrays.asList(twemproxyMachines.split(";"));
@@ -688,7 +692,7 @@ public class AppManageController extends BaseController {
             //2.根据应用类型获取部署拓扑信息
             switch (type) {
                 case 2: //  部署task :redis cluster
-                    taskid = taskService.addRedisClusterAppTask(appid, appAuditId, maxMemory, redisMachinelist, redisNum, redisResource.getName(),moduleinfos, -1);
+                    taskid = taskService.addRedisClusterAppTask(appid, appAuditId, maxMemory, appDeployInfolist, redisMachinelist, redisNum, redisResource.getName(),moduleinfos, -1);
                     break;
                 case 5: //  部署task :sentinel + redis
                     taskid = taskService.addRedisSentinelAppTask(appid, appAuditId, maxMemory, redisMachinelist, sentinelMachinelist, redisNum, sentinelNum, redisResource.getName(),moduleinfos, -1);

--- a/cachecloud-web/src/main/java/com/sohu/cache/web/service/InstancePortService.java
+++ b/cachecloud-web/src/main/java/com/sohu/cache/web/service/InstancePortService.java
@@ -50,7 +50,7 @@ public interface InstancePortService {
 	 */
 	public List<RedisServerNode> generateRedisServerNodeList(long appId, List<String> redisServerMachineList,
 															 int masterPerMachine, int maxMemory);
-	
+
 	/**
 	 * 生成redis sentinel 实例列表
 	 * @param appId

--- a/cachecloud-web/src/main/java/com/sohu/cache/web/service/impl/InstancePortServiceImpl.java
+++ b/cachecloud-web/src/main/java/com/sohu/cache/web/service/impl/InstancePortServiceImpl.java
@@ -94,7 +94,7 @@ public class InstancePortServiceImpl implements InstancePortService {
             redisServerNodeList.add(new RedisServerNode(masterHost, masterPort, InstanceRoleEnum.MASTER.getRole(),
                         maxMemory, "", 0));   
            
-            if (hostInfoArray.length >= 2) {
+            if (hostInfoArray.length >= 3) {
                 String slaveHost = hostInfoArray[2];
                 int slavePort = masterPort + ConstUtils.SLAVE_PORT_INCREASE;
                 while (checkHostPortExist(ipPortSetMap, slaveHost, slavePort)) {

--- a/cachecloud-web/src/main/webapp/WEB-INF/jsp/manage/appAudit/deploy/appDeployDetail.jsp
+++ b/cachecloud-web/src/main/webapp/WEB-INF/jsp/manage/appAudit/deploy/appDeployDetail.jsp
@@ -470,7 +470,7 @@
 														<br/><br/><br/>部署信息预览:<font color='red'>(*)</font>:
 													</label>
 													<div class="col-md-5">
-														<textarea rows="10" name="appDeployInfo" id="appDeployInfo" placeholder="部署详情" class="form-control" disabled="disabled"></textarea>
+														<textarea rows="10" name="appDeployInfo" id="appDeployInfo" placeholder="部署详情" class="form-control" ></textarea>
 													</div>
 													<br/>
 													<button id="clearInfo" class="btn btn-info" onclick="clearinfo()" data-toggle="modal" style="background:#CCCCCC;display:none;">清除</button>

--- a/cachecloud-web/src/main/webapp/WEB-INF/resources/manage/manage/appDeploy.js
+++ b/cachecloud-web/src/main/webapp/WEB-INF/resources/manage/manage/appDeploy.js
@@ -336,7 +336,30 @@ function addAppDeployTask() {
             moduleinfos +=  $("#moduleVersionId-"+moduleId+" option:selected").attr("versionid")+";";
         }
     })
+    // 获取原始字符串
+    var originalValue = $("#appDeployInfo").val();
 
+    // 使用换行符分割字符串，得到一组主机信息
+    var hostInfoArray = originalValue.split('\n');
+
+    // 初始化一个 Set 来存储不同的主机IP
+    var uniqueHostIPs = new Set();
+
+    // 遍历主机信息数组，提取每个主机的IP地址
+    for (var i = 0; i < hostInfoArray.length; i++) {
+        var hostInfo = hostInfoArray[i];
+        // 使用冒号分割每行信息
+        var parts = hostInfo.split(':');
+        // 确保有足够的部分
+        var firstIP = parts[0];
+        uniqueHostIPs.add(firstIP);
+        if (parts.length >= 3) {
+            var thirdIP = parts[2];
+            uniqueHostIPs.add(thirdIP);
+        }
+     }
+
+    redisMachines = Array.from(uniqueHostIPs).join(';');
     $.post(
         '/manage/app/addAppDeployTask.json',
         {
@@ -351,6 +374,7 @@ function addAppDeployTask() {
             sentinelNum: $("#sentinelNum option:selected").val(),
             pikaNum: $("#pikaNum option:selected").val(),
             twemproxyNum: $("#twemproxyNum option:selected").val(),
+            appDeployInfo: $("#appDeployInfo").val(),
             redisMachines: redisMachines,
             sentinelMachines: sentinelMachines,
             pikaMachines: pikaMachines,


### PR DESCRIPTION
痛点：
1. 在使用云主机部署 Redis 时，通常一个实例会部署一个Redis节点。假如我有 6 台云主机，想部署一个三主三从的 Redis Cluster，目前的实现方式是没办法做到的。
2. 在使用云主机部署 Redis 时，希望同一个分片的主从节点会分布在两个不同的可用区，目前自动生成没办法识别这些信息。
基于上述痛点，希望支持手动指定集群拓扑这种方式。


实现的方式：
1. 将部署页面“部署信息预览”设置为可编辑。
2. 将“部署信息预览”中指定的集群拓扑信息通过 appDeployInfo 传递给后端，同时 redisMachines 会基于 appDeployInfo 生成，不再是通过选定的Redis机器。
3. InstancePortServiceImpl.java 中会基于 appDeployInfo 指定的信息来生成实际的集群拓扑，不再是基于 redisMachines 和 masterPerMachine。
4. 兼容之前的部署方式，因为通过点击 “生成部署预览” 生成集群拓扑对应的接口（generateInstanceInfo）内容没有改变。